### PR TITLE
Add publishingType option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ sonatypeCentralUpload {
     username = "your-username"                      // This is your Sonatype generated username
     password = "your-password"                      // This is your sonatype generated password
     
-    archives = files(/*...*/)                       // This is a list of files to upload. Ideally you would point to your jar file, source and javadoc jar (required by central)
-    pom = file("path/to/pom.xml")                   // This is the pom file to upload. This is required by central
+    archives = files(/*...*/)                       // This is a list of files to upload. Ideally you would point to your jar file, source and javadoc jar (required by Central)
+    pom = file("path/to/pom.xml")                   // This is the pom file to upload. This is required by Central
     
     signingKey = "--BEGIN PGP PRIVATE KEY BLOCK--"  // This is your PGP private key. This is required to sign your files
     signingKeyPassphrase = "..."                    // This is your PGP private key passphrase (optional) to decrypt your private key
@@ -46,8 +46,8 @@ sonatypeCentralUpload {
     username = "your-username"                         // This is your Sonatype generated username
     password = "your-password"                         // This is your sonatype generated password
     
-    archives = files(/*...*/)                          // This is a list of files to upload. Ideally you would point to your jar file, source and javadoc jar (required by central)
-    pom = file("path/to/pom.xml")                      // This is the pom file to upload. This is required by central
+    archives = files(/*...*/)                          // This is a list of files to upload. Ideally you would point to your jar file, source and javadoc jar (required by Central)
+    pom = file("path/to/pom.xml")                      // This is the pom file to upload. This is required by Central
     
     signingKey = "--BEGIN PGP PRIVATE KEY BLOCK--"     // This is your PGP private key. This is required to sign your files
     signingKeyPassphrase = "..."                       // This is your PGP private key passphrase (optional) to decrypt your private key

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ sonatypeCentralUpload {
     signingKey = "--BEGIN PGP PRIVATE KEY BLOCK--"  // This is your PGP private key. This is required to sign your files
     signingKeyPassphrase = "..."                    // This is your PGP private key passphrase (optional) to decrypt your private key
     publicKey = "--BEGIN PGP PUBLIC KEY BLOCK--"    // This is your PGP public key (optional). To distribute later to verify your deployments.
+
+    publishingType = "AUTOMATIC"                    // This is the publishing strategy (optional). By default, the plugin automatically publishes the jar to Central. The possible values are: AUTOMATIC (default) or MANUAL.
 }
 ```
 
@@ -50,6 +52,8 @@ sonatypeCentralUpload {
     signingKey = "--BEGIN PGP PRIVATE KEY BLOCK--"     // This is your PGP private key. This is required to sign your files
     signingKeyPassphrase = "..."                       // This is your PGP private key passphrase (optional) to decrypt your private key
     publicKey = "--BEGIN PGP PUBLIC KEY BLOCK--"       // This is your PGP public key (optional). To distribute later to verify your deployments.
+
+    publishingType = "AUTOMATIC"                       // This is the publishing strategy (optional). By default, the plugin automatically publishes the jar to Central. The possible values are: AUTOMATIC (default) or MANUAL.
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ This is an unofficial gradle plugin to upload artifacts to [Sonatype Central Rep
 Groovy:
 ```groovy
 plugins {
-    id 'cl.franciscosolis.sonatype-central-upload' version '1.0.0'
+    id 'cl.franciscosolis.sonatype-central-upload' version '1.0.3'
 }
 ```
 
 Kotlin:
 ```kts
 plugins {
-    id("cl.franciscosolis.sonatype-central-upload") version "1.0.0"
+    id("cl.franciscosolis.sonatype-central-upload") version "1.0.3"
 }
 ```
 

--- a/SonatypeCentralUpload/build.gradle.kts
+++ b/SonatypeCentralUpload/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("com.gradle.plugin-publish") version "1.2.1"
 }
 
-version = "1.0.2"
+version = "1.0.3"
 group = "cl.franciscosolis"
 
 // Set up the publishing plugin

--- a/SonatypeCentralUpload/src/functionalTest/kotlin/cl/franciscosolis/sonatypecentralupload/SonatypeCentralUploadPluginFunctionalTest.kt
+++ b/SonatypeCentralUpload/src/functionalTest/kotlin/cl/franciscosolis/sonatypecentralupload/SonatypeCentralUploadPluginFunctionalTest.kt
@@ -74,6 +74,8 @@ class SonatypeCentralUploadPluginFunctionalTest {
                     archives = files("${mockJar.absolutePath}", "${mockSourcesJar.absolutePath}", "${mockJavadocJar.absolutePath}")
                     
                     pom = file("${mockPom.absolutePath}")
+
+                    publishingType = "AUTOMATIC"
                 }   
             }
         """.trimIndent())


### PR DESCRIPTION
The plugin, by default, publishes the jar to Central once it is validated. However, some library maintainers may want to publish it manually, as Maven has a policy of never deleting a jar once it's published.

This pull request introduces a new option to `sonatypeCentralUpload` task: `publishingType`. To prevent breaking previous users of the plugin, the option may be omitted. If omitted, it will continue behaving as the plugin behaves currently: it will publish the jar once it's validated:

```kotlin
sonatypeCentralUpload {
    username = "your-username"
    password = "your-password"

    archives = files(/*...*/)
    pom = file("path/to/pom.xml")

    signingKey = "--BEGIN PGP PRIVATE KEY BLOCK--"
    signingKeyPassphrase = "..."
    publicKey = "--BEGIN PGP PUBLIC KEY BLOCK--"

    publishingType = "MANUAL"
}
```

I've tested the plugin using Maven local. However, as I'm not the owner of the `cl.franciscosolis` on Central, my test always fails as `initPublishingProcess` throws an `IllegalStateException` when `deploymentStatus` returns `FAILED`.